### PR TITLE
Update list_item_crime.xml

### DIFF
--- a/app/src/main/res/layout/list_item_crime.xml
+++ b/app/src/main/res/layout/list_item_crime.xml
@@ -10,6 +10,7 @@
         android:id="@+id/crime_list_item_solvedCheckBox"
         android:gravity="center"
         android:layout_alignParentRight="true"
+        android:focusable="false"    
         android:enabled="false"
         android:padding="4dp"
         />


### PR DESCRIPTION
The checkbox is causing the problem. It's focusable so it's handling your click instead of ignoring it and letting it be handled by the ListView. Now, your app crashes when a list item is clicked (so you'll have to sort that out next) but the CrimeListFragment.onListItemClick method is being called.
